### PR TITLE
Scouter name from pin

### DIFF
--- a/resources/js/scoutingPASS.js
+++ b/resources/js/scoutingPASS.js
@@ -942,7 +942,6 @@ function updateQRHeader() {
   document.getElementById("display_qr-info").textContent = str;
 }
 
-
 function replaceValueInPosition(tabString, index, newValue) {
   // Split the string by tabs
   let parts = tabString.split("\t");


### PR DESCRIPTION
- Let's not use replace() just in case a scouter's PIN is the same as one of the team's numbers. Instead, we'll split at the tab characters then replace the contents of that specific item index.
- Refactored the QR code generate section to be more DRY (Don't Repeat Yourself).